### PR TITLE
feat: adicionada configuração do Swagger para documentação da API

### DIFF
--- a/codigo/backend/pom.xml
+++ b/codigo/backend/pom.xml
@@ -67,6 +67,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/codigo/backend/src/main/java/com/sg/reparos/config/OpenApiConfig.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/config/OpenApiConfig.java
@@ -1,0 +1,25 @@
+package com.sg.reparos.config;
+
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("SG Pequenos Reparos - API")
+                        .version("1.0")
+                        .description("API para gestão de serviços de pequenos reparos.")
+                        .contact(new Contact()
+                                .name("Equipe SG Pequenos Reparos")
+                                .email("contato@sgpequenosreparos.com")
+                        )
+                );
+    }
+}


### PR DESCRIPTION
## O que foi feito?

- Adicionado Swagger/OpenAPI utilizando a dependência springdoc-openapi-starter-webmvc-ui.
- Criado o endpoint de documentação automática em `http://localhost:8080/swagger-ui.html`.
- Adicionada classe de configuração personalizada (`OpenApiConfig`) para definir:
  - Título da API
  - Versão
  - Descrição
  - Contato da equipe