### PR TITLE
feat: adicionado controle de acesso baseado em ROLE (ADMIN e CLIENTE)

### DIFF
--- a/codigo/backend/src/main/java/com/sg/reparos/config/SecurityConfig.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/config/SecurityConfig.java
@@ -24,18 +24,20 @@ public class SecurityConfig {
     @Autowired
     private UsuarioDetailsServiceImpl userDetailsService;
 
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/auth/login", "/api/usuarios").permitAll()
-                .anyRequest().authenticated()
-            )
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/api/auth/login", "/api/usuarios").permitAll()
+            .requestMatchers("/api/admin/**").hasRole("ADMIN")  // 👈 Somente ADMIN
+            .requestMatchers("/api/cliente/**").hasRole("CLIENTE") // 👈 Somente CLIENTE
+            .anyRequest().authenticated()
+        )
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
-        return http.build();
-    }
+    return http.build();
+}
 
     @Bean
     public PasswordEncoder passwordEncoder() {

--- a/codigo/backend/src/main/java/com/sg/reparos/controller/AdminController.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/controller/AdminController.java
@@ -1,0 +1,15 @@
+package com.sg.reparos.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    @GetMapping("/dados")
+    public String dadosAdmin() {
+        return "Acesso permitido: Informações restritas para ADMIN.";
+    }
+}

--- a/codigo/backend/src/main/java/com/sg/reparos/controller/ClienteController.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/controller/ClienteController.java
@@ -1,0 +1,15 @@
+package com.sg.reparos.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/cliente")
+public class ClienteController {
+
+    @GetMapping("/perfil")
+    public String perfilCliente() {
+        return "Acesso permitido: Perfil do CLIENTE.";
+    }
+}


### PR DESCRIPTION
## O que foi feito?

- Implementado controle de acesso baseado em Role (perfil de usuário).
- Adicionados:
  - `AdminController` com rota protegida `/api/admin/dados` (somente ADMIN).
  - `ClienteController` com rota protegida `/api/cliente/perfil` (somente CLIENTE).
- Atualizado o `SecurityConfig` para:
  - Liberar `/api/auth/login` e `/api/usuarios`.
  - Proteger `/api/admin/**` para usuários com `ROLE_ADMIN`.
  - Proteger `/api/cliente/**` para usuários com `ROLE_CLIENTE`.
- Agora cada usuário só consegue acessar as rotas específicas de acordo com seu perfil.
