### PR TITLE
feat: implementar gerenciamento de usuários pelo admin

### DIFF
--- a/codigo/backend/src/main/java/com/sg/reparos/controller/UsuarioController.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/controller/UsuarioController.java
@@ -1,13 +1,16 @@
 package com.sg.reparos.controller;
 
+import com.sg.reparos.dto.UsuarioAdminDTO;
 import com.sg.reparos.dto.UsuarioUpdateDTO;
 import com.sg.reparos.model.Usuario;
+import com.sg.reparos.model.Usuario.TipoUsuario;
 import com.sg.reparos.service.UsuarioService;
 import com.sg.reparos.repository.UsuarioRepository;
 
 import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -40,9 +43,15 @@ public class UsuarioController {
                 .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
     }
 
-    @PostMapping
+    @PostMapping("/cadstro")
     public Usuario criarUsuario(@RequestBody @Valid Usuario usuario) {
         return usuarioService.salvarUsuario(usuario);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public Usuario salvarUsuarioPorAdmin(@RequestBody @Valid UsuarioAdminDTO dto) {
+        return usuarioService.salvarUsuarioPorAdmin(dto);
     }
 
     @PutMapping("/perfil")
@@ -53,8 +62,19 @@ public class UsuarioController {
         return usuarioService.atualizarUsuario(usuario.getId(), dto);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public Usuario atualizarUsuarioPorAdmin(@PathVariable Long id, @RequestBody @Valid UsuarioAdminDTO dto) {
+        return usuarioService.atualizarUsuarioPorAdmin(id, dto);
+    }
+
     @DeleteMapping("/{id}")
     public void deletarUsuario(@PathVariable Long id) {
         usuarioService.deletarUsuario(id);
+    }
+
+    @GetMapping("/tipos")
+    public TipoUsuario[] listarTiposUsuarios() {
+        return TipoUsuario.values();
     }
 }

--- a/codigo/backend/src/main/java/com/sg/reparos/dto/UsuarioAdminDTO.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/dto/UsuarioAdminDTO.java
@@ -1,0 +1,64 @@
+package com.sg.reparos.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class UsuarioAdminDTO {
+    @NotBlank
+    private String nome;
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String telefone;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String senha;
+
+    @NotBlank
+    private String tipo; // Ex: ROLE_ADMIN ou ROLE_CLIENTE
+
+    public String getNome() {
+        return nome;
+    }
+    public void setNome(String nome) {
+        this.nome = nome;
+    }
+    public String getEmail() {
+        return email;
+    }
+    public void setEmail(String email) {
+        this.email = email;
+    }
+    public String getTelefone() {
+        return telefone;
+    }
+    public void setTelefone(String telefone) {
+        this.telefone = telefone;
+    }
+    public String getUsername() {
+        return username;
+    }
+    public void setUsername(String username) {
+        this.username = username;
+    }
+    public String getSenha() {
+        return senha;
+    }
+    public void setSenha(String senha) {
+        this.senha = senha;
+    }
+    public String getTipo() {
+        return tipo;
+    }
+    public void setTipo(String tipo) {
+        this.tipo = tipo;
+    }
+}

--- a/codigo/backend/src/main/java/com/sg/reparos/service/UsuarioService.java
+++ b/codigo/backend/src/main/java/com/sg/reparos/service/UsuarioService.java
@@ -1,11 +1,14 @@
 package com.sg.reparos.service;
 
+import com.sg.reparos.dto.UsuarioAdminDTO;
 import com.sg.reparos.dto.UsuarioUpdateDTO;
 import com.sg.reparos.model.Usuario;
+import com.sg.reparos.model.Usuario.TipoUsuario;
 import com.sg.reparos.repository.UsuarioRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
 
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +39,30 @@ public class UsuarioService {
         return usuarioRepository.save(usuario);
     }
 
+    public Usuario salvarUsuarioPorAdmin(UsuarioAdminDTO dto) {
+    // Verificar se o username já existe
+    if (usuarioRepository.existsByUsername(dto.getUsername())) {
+        throw new RuntimeException("Username já cadastrado.");
+    }
+
+    Usuario usuario = new Usuario();
+    usuario.setNome(dto.getNome());
+    usuario.setEmail(dto.getEmail());
+    usuario.setTelefone(dto.getTelefone());
+    usuario.setUsername(dto.getUsername());
+    usuario.setSenha(passwordEncoder.encode(dto.getSenha()));
+
+    // Convertendo String para Enum
+    try {
+        TipoUsuario tipoUsuario = TipoUsuario.valueOf(dto.getTipo().toUpperCase());
+        usuario.setTipo(tipoUsuario);
+    } catch (IllegalArgumentException e) {
+        throw new RuntimeException("Tipo de usuário inválido: " + dto.getTipo());
+    }
+
+    return usuarioRepository.save(usuario);
+}
+
     public Usuario atualizarUsuario(Long id, UsuarioUpdateDTO dto) {
         Usuario usuario = usuarioRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
@@ -59,6 +86,31 @@ public class UsuarioService {
 
         return usuarioRepository.save(usuario);
     }
+
+public Usuario atualizarUsuarioPorAdmin(Long id, UsuarioAdminDTO dto) {
+    Usuario usuario = usuarioRepository.findById(id)
+            .orElseThrow(() -> new RuntimeException("Usuário não encontrado"));
+
+    usuario.setNome(dto.getNome());
+    usuario.setEmail(dto.getEmail());
+    usuario.setTelefone(dto.getTelefone());
+    usuario.setUsername(dto.getUsername());
+
+    // Conversão String -> Enum
+    try {
+        TipoUsuario tipoUsuario = TipoUsuario.valueOf(dto.getTipo().toUpperCase());
+        usuario.setTipo(tipoUsuario); // Agora estamos passando o enum
+    } catch (IllegalArgumentException e) {
+        throw new RuntimeException("Tipo de usuário inválido: " + dto.getTipo());
+    }
+
+    if (dto.getSenha() != null && !dto.getSenha().isBlank()) {
+        usuario.setSenha(passwordEncoder.encode(dto.getSenha()));
+    }
+
+    return usuarioRepository.save(usuario);
+}
+
 
     public void deletarUsuario(Long id) {
         usuarioRepository.deleteById(id);


### PR DESCRIPTION
# O que foi feito:
Implementação das funcionalidades de gerenciamento de usuários pelo administrador no backend.

- Criado DTO `UsuarioAdminDTO` para cadastro e atualização de usuários com atribuição de tipo (`ADMIN` ou `CLIENTE`).
- Implementado endpoint de cadastro de usuários pelo Admin (`POST /api/usuarios`).
- Implementado endpoint de atualização de usuários pelo Admin (`PUT /api/usuarios/{id}`).
- Criado endpoint de listagem dos tipos de usuários (`GET /api/usuarios/tipos`).
- Endpoint separado para cadastro público de novos clientes (`POST /api/usuarios/registro`).
- Protegidos os endpoints administrativos com `@PreAuthorize("hasRole('ADMIN')")`.

## Checklist
- [x] Cadastro de usuários pelo Admin
- [x] Edição de usuários pelo Admin
- [x] Listagem de tipos de usuários (público)
- [x] Cadastro público de clientes funcionando
- [x] Proteção adequada dos endpoints

## Issue relacionada
Closes #Sprint3-GerenciamentoUsuarios